### PR TITLE
fix: No comma at each end of line in C header file style

### DIFF
--- a/xxd.go
+++ b/xxd.go
@@ -636,7 +636,7 @@ func xxd(r io.Reader, w io.Writer, fname string) error {
 				// don't add spaces to EOL
 				if i != n-1 {
 					w.Write(commaSpace)
-				} else if doCEnd {
+				} else if n == cols {
 					w.Write(comma)
 				}
 			}


### PR DESCRIPTION
Before:
unsigned char hello_txt[] = {
  0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x2c, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64
  0x21
};
unsigned int hello_txt_len = 13;

After:
unsigned char hello_txt[] = {
  0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x2c, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64,
  0x21
};
unsigned int hello_txt_len = 13;

Native xxd V1.10 27oct98 on Cygwin:
unsigned char hello_txt[] = {
  0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x2c, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64,
  0x21
};
unsigned int hello_txt_len = 13;