### PR TITLE
Minor improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/felixge/go-xxd
 
-go 1.16
+go 1.18
 
 require github.com/ogier/pflag v0.0.1

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/felixge/go-xxd
+
+go 1.16
+
+require github.com/ogier/pflag v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/ogier/pflag v0.0.1 h1:RW6JSWSu/RkSatfcLtogGfFgpim5p7ARQ10ECk5O750=
+github.com/ogier/pflag v0.0.1/go.mod h1:zkFki7tvTa0tafRvTBIZTvzYyAu6kQhPZFnshFFPE+g=

--- a/xxd_test.go
+++ b/xxd_test.go
@@ -19,10 +19,12 @@ func TestXXD(t *testing.T) {
 	if *xxdFile == "" {
 		t.Skip("-xxdFile argument not given")
 	}
+
 	data, err := ioutil.ReadFile(*xxdFile)
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	test := func(fn func(r io.Reader, w io.Writer, s string) error) func(n uint64) []string {
 		return func(n uint64) []string {
 			size := n % uint64(len(data))
@@ -34,6 +36,7 @@ func TestXXD(t *testing.T) {
 			return strings.Split(out.String(), "\n")
 		}
 	}
+
 	if err := quick.CheckEqual(test(xxd), test(xxdNative), nil); err != nil {
 		cErr := err.(*quick.CheckEqualError)
 		size := cErr.In[0].(uint64) % uint64(len(data))


### PR DESCRIPTION
Changes include:
- Idiomatic style
- Formatting
- Remove unused vars
- Use `go 1.18` in go.mod

Optimizations include:
- Eliminate unnecessary bound checks
  (-gcflags="-d=ssa/check_bce/debug=1"): Reduce from 54 to 46 checks.
- Inline function by reducing costs (eg. Convert op "range" to normal
  loops, etc.)
- Reuse vars instead of allocating them in every iteration, etc.

Benchmarks are taken on:
```
Go version: go1.16.3 linux/arm64
OS, Arch: linux (manjaro), arm64 (rpi)
```

Note:
```
Perflock is used for stable benchmarks and Benchstat to compute and
compare statistics about benchmarks.
```

Result:
$ go test -bench=. -benchmem -count=10

```
$ benchstat old.txt new.txt
name   old time/op    new time/op    delta
XXD-4    73.6ns ± 1%    72.8ns ± 0%  -1.13%  (p=0.000 n=10+10)

name   old alloc/op   new alloc/op   delta
XXD-4     0.00B          0.00B         ~     (all equal)

name   old allocs/op  new allocs/op  delta
XXD-4      0.00           0.00         ~     (all equal)
```