### PR TITLE
create outfile

### DIFF
--- a/xxd.go
+++ b/xxd.go
@@ -774,7 +774,7 @@ func main() {
 
 	var outFile *os.File
 	if flag.NArg() == 2 {
-		outFile, err = os.Open(flag.Args()[1])
+		outFile, err = os.Create(flag.Args()[1])
 		if err != nil {
 			log.Fatalln(err)
 		}


### PR DESCRIPTION
Usage help text of `go-xxd` tools specifies how to output the dump file but this option doesn't work
```
go-xxd --help
Usage:
       xxd [options] [infile [outfile]]
    or
       xxd -r [-s offset] [-c cols] [--ps] [infile [outfile]]
```